### PR TITLE
load transforms specified as strings, close #6

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -14,6 +14,7 @@ var USAGE = `
 
     -h, --help        print usage
     -v, --version     print version
+    -t, --transform   add a transform
 
   Examples:
 
@@ -54,7 +55,10 @@ var argv = minimist(process.argv.slice(2), {
   } else if (argv.version) {
     console.log(require('./package.json').version)
   } else {
-    pump(Documentify(entry).bundle(), process.stdout, function (err) {
+    var bundler = Documentify(entry, null, {
+      transform: argv.transform
+    })
+    pump(bundler.bundle(), process.stdout, function (err) {
       if (err) {
         console.error(err)
         process.exit(1)

--- a/bin.js
+++ b/bin.js
@@ -55,7 +55,7 @@ var argv = minimist(process.argv.slice(2), {
   } else if (argv.version) {
     console.log(require('./package.json').version)
   } else {
-    var bundler = Documentify(entry, null, {
+    var bundler = Documentify(entry, {
       transform: argv.transform
     })
     pump(bundler.bundle(), process.stdout, function (err) {

--- a/example/hello-world.js
+++ b/example/hello-world.js
@@ -1,0 +1,16 @@
+var fromString = require('from2-string')
+var hyperstream = require('hyperstream')
+
+/**
+ * A basic example transform using `hyperstream`.
+ */
+
+module.exports = function () {
+  var bodyStream = fromString('<h1>hello world</h1>')
+
+  return hyperstream({
+    body: {
+      _appendHtml: bodyStream
+    }
+  })
+}

--- a/example/package.json
+++ b/example/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "documentify": {
-    "transform": []
+    "transform": [
+      "./hello-world"
+    ]
   }
 }

--- a/index.js
+++ b/index.js
@@ -20,6 +20,11 @@ function Documentify (entry, html, opts) {
 
   assert.equal(typeof entry, 'string', 'documentify: entry should be type string')
 
+  if (typeof html === 'object') {
+    opts = html
+    html = null
+  }
+
   if (html) {
     assert.equal(typeof html, 'string', 'documentify: html should be type string')
   }

--- a/index.js
+++ b/index.js
@@ -33,8 +33,18 @@ function Documentify (entry, html, opts) {
   this._ready = true
 
   if (opts.transform) {
-    if (Array.isArray(opts.transform)) this.transforms = this.transforms.concat(opts.transform)
-    else this.transforms.push(opts.transform)
+    var self = this
+    var transforms = opts.transform
+    if (!Array.isArray(transforms)) {
+      transforms = [transforms]
+    }
+    transforms.forEach(function (t) {
+      if (Array.isArray(t)) {
+        self.transform(t[0], t[1])
+      } else {
+        self.transform(t)
+      }
+    })
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -14,12 +14,15 @@
     "fast-json-parse": "^1.0.2",
     "findup": "^0.1.5",
     "from2-string": "^1.1.0",
+    "inherits": "^2.0.3",
     "minimist": "^1.2.0",
     "pump": "^1.0.2",
-    "readable-stream": "^2.3.3"
+    "readable-stream": "^2.3.3",
+    "resolve": "^1.4.0"
   },
   "devDependencies": {
     "dependency-check": "^2.9.1",
+    "hyperstream": "^1.2.2",
     "standard": "^10.0.2",
     "tape": "^4.7.0"
   },


### PR DESCRIPTION
this patch adds support for loading transforms via:

```js
// package.json
{
  "documentify": {
    "transform": [
      "whateverify"
    ]
  }
}
```
```js
// build.js
var d = documentify(entry, null, {
  transform: ['whateverify']
})
d.transform('whateverify')
```
```bash
documentify -t whateverify
```

this covers all current ways of specifying transforms.

it might be a good idea to add `tape` at this point but for now i just added a transform to the example's package.json. I also ran bankai with this patch applied to make sure that the `.transform(function)` style still works and that seemed fine.