### PR TITLE
use existing source file

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,8 @@ var fs = require('fs')
 
 module.exports = Documentify
 
+var defaultHtml = '<!DOCTYPE html><html><head></head><body></body></html>'
+
 function Documentify (entry, html, opts) {
   if (!(this instanceof Documentify)) return new Documentify(entry, html, opts)
 
@@ -31,7 +33,7 @@ function Documentify (entry, html, opts) {
 
   opts = opts || {}
 
-  this.html = html || '<!DOCTYPE html><html><head></head><body></body></html>'
+  this.html = html
   this.transforms = []
   this.entry = entry
   this.basedir = opts.basedir || process.cwd()
@@ -159,7 +161,17 @@ Documentify.prototype.bundle = function () {
   }
 
   function createSource (done) {
-    source = fromString(self.html)
-    done()
+    if (typeof self.html === 'string') {
+      source = fromString(self.html)
+      return done()
+    }
+    resolve(self.entry, { extensions: [ '.html' ] }, function (err, entry) {
+      if (err) {
+        source = fromString(defaultHtml)
+      } else {
+        source = fs.createReadStream(entry)
+      }
+      done()
+    })
   }
 }


### PR DESCRIPTION
This makes `documentify ./xyz.html` use xyz.html as input.

When an html string is given, use it. Otherwise if the entry point
exists, stream from it. If the entry point does not exist, use the
default html string.

Doing `documentify .` or `documentify('.')` will use `./index.html`
if it exists, because it uses `resolve()` to find the file.

The 'default html' behaviour is a bit strange here, if you typoed
your file name it'll also use the default instead of erroring. I
thought it may be better to only use the default html if the entry
point is omitted, but:

 - we still need to find the package.json relative to the entry
  point (could be mitigated with a `basedir` option)
 - `documentify .` on a directory with a package.json but no
  index.html is a neat API and it'd be a shame if that didn't work

So I don't know what the best way to deal with that is. Thoughts?