### PR TITLE
Make transform() chainable

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,6 +81,8 @@ Documentify.prototype.transform = function (transform, opts) {
   } else {
     this.transforms.push([ transform, opts ])
   }
+
+  return this
 }
 
 Documentify.prototype.bundle = function () {


### PR DESCRIPTION
Noticed that `.transform(t1).transform(t2)` didn't work while working on tests. Now it does 🙌 