### PR TITLE
Some tests, closes #1

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "deps": "dependency-check . && dependency-check . --extra --no-dev",
     "start": "node .",
-    "test": "standard && npm run deps && ./bin.js ./example"
+    "test": "standard && npm run deps && node test/index.js"
   },
   "dependencies": {
     "ansi-escape-sequences": "^3.0.0",
@@ -22,10 +22,13 @@
     "resolve": "^1.4.0"
   },
   "devDependencies": {
+    "assert-html": "^1.1.5",
+    "concat-stream": "^1.6.0",
+    "dedent": "^0.7.0",
     "dependency-check": "^2.9.1",
     "hyperstream": "^1.2.2",
     "standard": "^10.0.2",
-    "tape": "^4.7.0"
+    "tape": "^4.8.0"
   },
   "keywords": [
     "html",

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,1 @@
+require('./input')

--- a/test/index.js
+++ b/test/index.js
@@ -1,1 +1,2 @@
 require('./input')
+require('./transforms')

--- a/test/input.html
+++ b/test/input.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>input.html</title>
+  </head>
+  <body>
+    <h1>some source from a file</h1>
+  </body>
+</html>

--- a/test/input.js
+++ b/test/input.js
@@ -1,0 +1,64 @@
+var test = require('tape')
+var path = require('path')
+var documentify = require('../')
+var concat = require('concat-stream')
+var assertHtml = require('assert-html')
+var dedent = require('dedent')
+
+test('input', function (t) {
+  t.test('uses input text if specified', function (t) {
+    t.plan(10)
+    var sourceHtml = `
+      <!DOCTYPE html>
+      <html>
+      <head>
+        <title>test</title>
+      </head>
+      <body>
+        beep boop
+      </body>
+      </html>
+    `.replace(/\n +/g, '')
+
+    documentify(path.join(__dirname, 'test.html'), sourceHtml)
+      .bundle()
+      .pipe(concat({ encoding: 'string' }, function (html) {
+        assertHtml(t, sourceHtml, html)
+      }))
+  })
+
+  t.test('defaults to empty document', function (t) {
+    t.plan(7)
+    documentify(path.join(__dirname, 'test.html'))
+      .bundle()
+      .pipe(concat({ encoding: 'string' }, function (html) {
+        assertHtml(t, `
+          <!DOCTYPE html>
+          <html>
+            <head></head>
+            <body></body>
+          </html>
+        `.replace(/\n +/g, ''), html)
+      }))
+  })
+
+  t.test('reads html source file if it exists', function (t) {
+    t.plan(14)
+    var expected = dedent`
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>input.html</title>
+        </head>
+        <body>
+          <h1>some source from a file</h1>
+        </body>
+      </html>
+    `.replace(/\n +/g, '')
+    documentify(path.join(__dirname, 'input.html'))
+      .bundle()
+      .pipe(concat({ encoding: 'string' }, function (html) {
+        assertHtml(t, expected, html.replace(/\n +/g, ''))
+      }))
+  })
+})

--- a/test/transforms.js
+++ b/test/transforms.js
@@ -1,0 +1,52 @@
+var test = require('tape')
+var path = require('path')
+var Transform = require('readable-stream').Transform
+var concat = require('concat-stream')
+var documentify = require('../')
+
+test('transforms', function (t) {
+  var testPath = path.join(__dirname, 'test.html')
+  t.test('should pipe transforms in order', function (t) {
+    t.plan(2)
+
+    function t1 () {
+      return append('transform1')
+    }
+    function t2 () {
+      return append('transform2')
+    }
+
+    documentify(testPath)
+      .transform(t1)
+      .transform(t2)
+      .bundle()
+      .pipe(concat({ encoding: 'string' }, function (result) {
+        var lines = result.split(/\n/g)
+        t.equal(lines.pop(), 'transform2')
+        t.equal(lines.pop(), 'transform1')
+      }))
+  })
+
+  t.test('should find transforms in package.json', function (t) {
+    t.plan(1)
+
+    documentify(path.join(__dirname, 'transforms/'))
+      .bundle()
+      .pipe(concat({ encoding: 'string' }, function (result) {
+        t.equal(result, 'transform from package.json')
+      }))
+  })
+})
+
+function append (text) {
+  return new Transform({
+    write (chunk, enc, cb) {
+      this.push(chunk)
+      cb()
+    },
+    flush (cb) {
+      this.push('\n' + text)
+      cb()
+    }
+  })
+}

--- a/test/transforms/package.json
+++ b/test/transforms/package.json
@@ -1,0 +1,7 @@
+{
+  "documentify": {
+    "transform": [
+      "./transform"
+    ]
+  }
+}

--- a/test/transforms/transform.js
+++ b/test/transforms/transform.js
@@ -1,0 +1,14 @@
+var Transform = require('readable-stream').Transform
+
+module.exports = function () {
+  return new Transform({
+    write: function (chunk, enc, cb) {
+      cb()
+    },
+    flush: function (cb) {
+      this.push('transform from package.json')
+      this.push(null)
+      cb()
+    }
+  })
+}


### PR DESCRIPTION
Don't have a test for transform order when using `.transform()` *and* a `documentify.transform` key in package.json, because that'll probably flip soon anyway