### PR TITLE
Run transforms specified in package.json first

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,9 +135,9 @@ Documentify.prototype.bundle = function () {
         var t = d.transform
         if (!t || !Array.isArray(t)) return done()
 
-        loadTransforms(t, pathname, function (err, _transforms) {
+        loadTransforms(t, pathname, function (err, packageTransforms) {
           if (err) return done(err)
-          self.transforms = self.transforms.concat(_transforms)
+          self.transforms = packageTransforms.concat(self.transforms)
           done()
         })
       })

--- a/test/order/another.js
+++ b/test/order/another.js
@@ -1,0 +1,14 @@
+var Transform = require('readable-stream').Transform
+
+module.exports = function () {
+  return Transform({
+    transform (chunk, enc, cb) {
+      this.push(chunk)
+      cb()
+    },
+    flush (cb) {
+      this.push('\npackage.json append')
+      cb()
+    }
+  })
+}

--- a/test/order/package.json
+++ b/test/order/package.json
@@ -1,0 +1,8 @@
+{
+  "documentify": {
+    "transform": [
+      "./transform",
+      "./another"
+    ]
+  }
+}

--- a/test/order/transform.js
+++ b/test/order/transform.js
@@ -1,0 +1,7 @@
+var PassThrough = require('readable-stream').PassThrough
+
+module.exports = function () {
+  var ps = PassThrough()
+  ps.push('package.json prepend\n')
+  return ps
+}


### PR DESCRIPTION
This is the same behaviour as browserify.

Now something like:

```js
documentify('./index.html')
  .transform('html-minify-stream')
```

with a package.json containing:

```json
{
  "documentify": {
    "transform": ["pug-to-html"]
  }
}
```

would run pug-to-html first, and html-minify-stream second. (pug-to-html is not an existing module but it could be!)