### PR TITLE
Accept stream input for `html`

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ function transform (opts) {
 ### `document = documentify(entry, [html], [opts])`
 Create a new documentify instance. If `entry` is a `.html` file, it'll be
 used as the source. If `entry` is falsy and `html` is a string or readable
-stream, that will be used as the input instead. Otherwise `entry` is falsey
-and `html` is omitted, it uses an empty HTML file with just a body and head
-as the source.
+stream, that will be used as the input instead. Otherwise if `entry` is falsy
+and `html` is omitted, an empty HTML file with just a body and head will be
+used as the source.
 
 ### `document.transform(fn, [opts])`
 Pass a transform to the document instance

--- a/README.md
+++ b/README.md
@@ -66,9 +66,11 @@ function transform (opts) {
 
 ## API
 ### `document = documentify(entry, [html], [opts])`
-Create a new documentify instance. If `entry` is a `.html` file or a readable
-stream, it'll be used as the source. Otherwise uses an empty HTML file with
-just a body and head as the source.
+Create a new documentify instance. If `entry` is a `.html` file, it'll be
+used as the source. If `entry` is falsy and `html` is a string or readable
+stream, that will be used as the input instead. Otherwise `entry` is falsey
+and `html` is omitted, it uses an empty HTML file with just a body and head
+as the source.
 
 ### `document.transform(fn, [opts])`
 Pass a transform to the document instance

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Modular HTML bundler.
     Start bundling HTML
     $ documentify .
 
+    Bundle HTML from a stream
+    $ cat index.html | documentify
+
   Running into trouble? Feel free to file an issue:
   https://github.com/stackhtml/documentify/issues/new
 
@@ -63,9 +66,9 @@ function transform (opts) {
 
 ## API
 ### `document = documentify(entry, [html], [opts])`
-Create a new documentify instance. If `entry` is a `.html` file, it'll be used
-as the source. Otherwise uses an empty HTML file with just a body and head as
-the source.
+Create a new documentify instance. If `entry` is a `.html` file or a readable
+stream, it'll be used as the source. Otherwise uses an empty HTML file with
+just a body and head as the source.
 
 ### `document.transform(fn, [opts])`
 Pass a transform to the document instance

--- a/bin.js
+++ b/bin.js
@@ -46,9 +46,13 @@ var argv = subarg(process.argv.slice(2), {
 ;(function main (argv) {
   var entry = argv._[0]
 
-  // If entry isn't an absolute path, convert to absolute path
-  if (!entry) entry = process.cwd()
-  if (!/^\//.test(entry)) entry = path.join(process.cwd(), entry)
+  if (process.stdin.isTTY) {
+    // If entry isn't an absolute path, convert to absolute path
+    if (!entry) entry = process.cwd()
+    if (!/^\//.test(entry)) entry = path.join(process.cwd(), entry)
+  } else {
+    entry = process.stdin
+  }
 
   if (argv.help) {
     console.log(USAGE)
@@ -72,6 +76,7 @@ function clr (text, color) {
 }
 
 function normalizeTransforms (transforms) {
+  if (!transforms) return []
   if (!Array.isArray(transforms)) transforms = [transforms]
   return transforms.map(function (t) {
     if (typeof t === 'object' && Array.isArray(t._)) {

--- a/bin.js
+++ b/bin.js
@@ -45,13 +45,14 @@ var argv = subarg(process.argv.slice(2), {
 
 ;(function main (argv) {
   var entry = argv._[0]
+  var html = null
 
-  if (process.stdin.isTTY) {
-    // If entry isn't an absolute path, convert to absolute path
-    if (!entry) entry = process.cwd()
-    if (!/^\//.test(entry)) entry = path.join(process.cwd(), entry)
-  } else {
-    entry = process.stdin
+  // If entry isn't an absolute path, convert to absolute path
+  if (!entry) entry = process.cwd()
+  if (!/^\//.test(entry)) entry = path.join(process.cwd(), entry)
+
+  if (!process.stdin.isTTY) {
+    html = process.stdin
   }
 
   if (argv.help) {
@@ -59,7 +60,7 @@ var argv = subarg(process.argv.slice(2), {
   } else if (argv.version) {
     console.log(require('./package.json').version)
   } else {
-    var bundler = Documentify(entry, {
+    var bundler = Documentify(entry, html, {
       transform: normalizeTransforms(argv.transform)
     })
     pump(bundler.bundle(), process.stdout, function (err) {

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = Documentify
 var defaultHtml = '<!DOCTYPE html><html><head></head><body></body></html>'
 
 function isStream (maybe) {
-  return !!maybe && typeof maybe === 'object' && typeof maybe.pipe === 'function'
+  return maybe !== null && typeof maybe === 'object' && typeof maybe.pipe === 'function'
 }
 
 function Documentify (entry, html, opts) {

--- a/test/input.js
+++ b/test/input.js
@@ -8,21 +8,18 @@ var fromString = require('from2-string')
 
 test('input', function (t) {
   t.test('throws if the input is not a string', function (t) {
-    t.plan(6)
+    t.plan(3)
 
-    var notAString = [
+    var truthyButNotAString = [
       12,
-      null,
-      undefined,
       {foo: 'bar'},
-      true,
-      false
+      true
     ]
 
-    for (var i = 0; i < notAString.length; i++) {
+    for (var i = 0; i < truthyButNotAString.length; i++) {
       t.throws(function () {
-        documentify(notAString[i]).bundle()
-      }, /entry should be type string or a stream/)
+        documentify(truthyButNotAString[i]).bundle()
+      }, /entry should be type string/)
     }
   })
 
@@ -47,6 +44,29 @@ test('input', function (t) {
       }))
   })
 
+  t.test('accepts a stream without options provided', function (t) {
+    t.plan(10)
+
+    var sourceHtml = `
+      <!DOCTYPE html>
+      <html>
+      <head>
+        <title>test</title>
+      </head>
+      <body>
+        beep boop
+      </body>
+      </html>
+    `.replace(/\n +/g, '')
+    var sourceStream = fromString(sourceHtml)
+
+    documentify(null, sourceStream)
+      .bundle()
+      .pipe(concat({ encoding: 'string' }, function (html) {
+        assertHtml(t, sourceHtml, html)
+      }))
+  })
+
   t.test('accepts a stream', function (t) {
     t.plan(10)
 
@@ -63,7 +83,7 @@ test('input', function (t) {
     `.replace(/\n +/g, '')
     var sourceStream = fromString(sourceHtml)
 
-    documentify(sourceStream, {})
+    documentify(null, sourceStream, {})
       .bundle()
       .pipe(concat({ encoding: 'string' }, function (html) {
         assertHtml(t, sourceHtml, html)

--- a/test/input.js
+++ b/test/input.js
@@ -44,30 +44,7 @@ test('input', function (t) {
       }))
   })
 
-  t.test('accepts a stream without options provided', function (t) {
-    t.plan(10)
-
-    var sourceHtml = `
-      <!DOCTYPE html>
-      <html>
-      <head>
-        <title>test</title>
-      </head>
-      <body>
-        beep boop
-      </body>
-      </html>
-    `.replace(/\n +/g, '')
-    var sourceStream = fromString(sourceHtml)
-
-    documentify(null, sourceStream)
-      .bundle()
-      .pipe(concat({ encoding: 'string' }, function (html) {
-        assertHtml(t, sourceHtml, html)
-      }))
-  })
-
-  t.test('accepts a stream', function (t) {
+  t.test('accepts a html stream', function (t) {
     t.plan(10)
 
     var sourceHtml = `
@@ -84,6 +61,29 @@ test('input', function (t) {
     var sourceStream = fromString(sourceHtml)
 
     documentify(null, sourceStream, {})
+      .bundle()
+      .pipe(concat({ encoding: 'string' }, function (html) {
+        assertHtml(t, sourceHtml, html)
+      }))
+  })
+
+  t.test('accepts a html stream without options provided', function (t) {
+    t.plan(10)
+
+    var sourceHtml = `
+      <!DOCTYPE html>
+      <html>
+      <head>
+        <title>test</title>
+      </head>
+      <body>
+        beep boop
+      </body>
+      </html>
+    `.replace(/\n +/g, '')
+    var sourceStream = fromString(sourceHtml)
+
+    documentify(null, sourceStream)
       .bundle()
       .pipe(concat({ encoding: 'string' }, function (html) {
         assertHtml(t, sourceHtml, html)


### PR DESCRIPTION
This PR addresses #16 by allowing the `html` argument to be a stream (`stdin`, most relevantly). That makes `documentify(null, process.stdin)` valid.

In order to make that choice in the `bin` script, it checks `process.stdin.isTTY` so that two valid cli usages are:

```
$ cat test/input.html | ./bin.js 
<!DOCTYPE html>
<html>
  <head>
    <title>input.html</title>
  </head>
  <body>
    <h1>some source from a file</h1>
  </body>
</html>
```

```
$ ./bin.js test/input.html 
<!DOCTYPE html>
<html>
  <head>
    <title>input.html</title>
  </head>
  <body>
    <h1>some source from a file</h1>
  </body>
</html>
```

(It also fixes `normalizeTransforms` in the currently unpublished master branch to allow an empty array of transforms as opposed to returning `[undefined]`, which causes it to fail).